### PR TITLE
fix(VideoLoader): autoplay issue in safari on ios and osx

### DIFF
--- a/src/app/video-loader/video-loader/video-loader.component.html
+++ b/src/app/video-loader/video-loader/video-loader.component.html
@@ -2,7 +2,7 @@
   *ngIf="video"
   [src]="src"
   [class]="videoClass"
-  [poster]="poster"
+  [attr.poster]="poster"
   [autoplay]="autoplay"
   [loop]="loop"
   [muted]="muted"


### PR DESCRIPTION
When controls attribute is not specified video autoplay behaviour becomes flaky. After testing it
appears that this maybe due to the `poster` property of the video element and how the property is
being set. Setting the `poster` attribute rather than the property seems to resolve the issue.